### PR TITLE
makeExport should reset with null

### DIFF
--- a/can-globals-proto.js
+++ b/can-globals-proto.js
@@ -141,7 +141,7 @@ Globals.prototype.makeExport = function(key) {
 			return this.getKeyValue(key);
 		}
 
-		if (typeof value === 'undefined') {
+		if (typeof value === 'undefined' || value === null) {
 			this.deleteKeyValue(key);
 		} else {
 			this.setKeyValue(key, value);

--- a/can-globals-test.js
+++ b/can-globals-test.js
@@ -179,3 +179,14 @@ QUnit.test('make export of key', function() {
 	e(undefined);
 	equal(e(), 'bar');
 });
+
+QUnit.test('reset export value with null (can-stache#288)', function() {
+	var globals = new Globals();
+	globals.define('foo', 'bar');
+	var e = globals.makeExport('foo');
+	equal(e(), 'bar');
+	e('baz');
+	equal(e(), 'baz');
+	e(null);
+	equal(e(), 'bar');
+});


### PR DESCRIPTION
In some cases, the export helper will be called with `null` ([can-stache/test/stache-test.js#L101](https://github.com/canjs/can-stache/blob/master/test/stache-test.js#L101)) and this should reset the value to match the legacy API.

- Added check for `null` in `makeExport` setter
- Added test for this issue

closes canjs/can-stache#288