### PR TITLE
Fix bug with makeExport helper setting its value to a function

### DIFF
--- a/can-globals-proto.js
+++ b/can-globals-proto.js
@@ -134,7 +134,13 @@ Globals.prototype.makeExport = function(key) {
 		if (typeof value === 'undefined' || value === null) {
 			this.deleteKeyValue(key);
 		} else {
-			this.setKeyValue(key, value);
+			if (typeof value === 'function'){
+				this.setKeyValue(key, function(){
+					return value;
+				});
+			}else{
+				this.setKeyValue(key, value);
+			}
 			return value;
 		}
 	}.bind(this);

--- a/can-globals-test.js
+++ b/can-globals-test.js
@@ -232,3 +232,17 @@ QUnit.test('reset triggers events', function(){
 	equal(fooHandler.called, true);
 	equal(barHandler.called, true);
 });
+
+QUnit.test('export helper value can be set to a function', function(){
+	var globals = new Globals();
+	var spy = sinon.spy();
+	globals.setKeyValue('foo', function(){
+		return function(){};
+	});
+	var fooExport = globals.makeExport('foo');
+	fooExport(spy);
+	QUnit.equal(typeof fooExport(), 'function');
+	QUnit.equal(spy.callCount, 0);
+	fooExport()();
+	QUnit.equal(spy.callCount, 1);
+});


### PR DESCRIPTION
When using the getter/setter created by the `makeExport` helper, setting the value to a function, for example, `MutationObserver`, would cause `setKeyValue` to call MutationObserver in an attempt to use its return value.