### PR TITLE
Add is-node & fix is-browser-window not to check for SimpleDOM

### DIFF
--- a/can-globals.js
+++ b/can-globals.js
@@ -7,5 +7,6 @@ require('./document/document');
 require('./location/location');
 require('./mutation-observer/mutation-observer');
 require('./is-browser-window/is-browser-window');
+require('./is-node/is-node');
 
 module.exports = globals;

--- a/is-browser-window/is-browser-window.js
+++ b/is-browser-window/is-browser-window.js
@@ -22,8 +22,10 @@ var globals = require('can-globals/can-globals-instance');
  */
 
 globals.define('isBrowserWindow', function(){
+	var isNode = globals.getKeyValue('isNode');
 	return typeof window !== "undefined" &&
-		typeof document !== "undefined" && typeof SimpleDOM === "undefined";
+		typeof document !== "undefined" &&
+		isNode === false;
 });
 
 module.exports = globals.makeExport('isBrowserWindow');

--- a/is-browser-window/is-browser-window.js
+++ b/is-browser-window/is-browser-window.js
@@ -2,6 +2,9 @@
 
 var globals = require('can-globals/can-globals-instance');
 
+// This module depends on isNode being defined
+require('../is-node/is-node');
+
 /**
  * @module {function} can-globals/is-browser-window/is-browser-window is-browser-window
  * @parent can-globals/modules

--- a/is-node/is-node-test.js
+++ b/is-node/is-node-test.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var QUnit = require('../../test-wrapper');
+var isNode = require('./is-node');
+
+QUnit.module("can-globals/is-node/is-node");
+
+QUnit.test("basics", function(assert){
+	assert.equal(typeof isNode(), "boolean");
+});

--- a/is-node/is-node.js
+++ b/is-node/is-node.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var globals = require('can-globals/can-globals-instance');
+
+/**
+ * @module {function} can-globals/is-node/is-node is-node
+ * @parent can-globals/modules
+ * @description Determines if your code is running in [Node.js](https://nodejs.org).
+ * @signature `isNode()`
+ *
+ * ```js
+ * var isNode = require("can-globals/is-node/is-node");
+ * var GLOBAL = require("can-globals/global/global");
+ *
+ * if(isNode()) {
+ *   console.log(GLOBAL() === global); // -> true
+ * }
+ * ```
+ *
+ * @return {Boolean} True if running in Node.js
+ */
+
+globals.define('isNode', function(){
+	return typeof process === "object" &&
+		{}.toString.call(process) === "[object process]";
+});
+
+module.exports = globals.makeExport('isNode');

--- a/test.js
+++ b/test.js
@@ -3,3 +3,4 @@ require('./can-globals-test');
 require('./global/global-test');
 require('./location/location-test');
 require('./is-browser-window/is-browser-window-test');
+require('./is-node/is-node-test');


### PR DESCRIPTION
This adds [is-node from can-util](https://github.com/canjs/can-util/tree/7e8669a666072dcbdcc34402b640a67d38ea5784/js/is-node) and changes is-browser-window to use `is-node` instead of checking for SimpleDOM’s presence.

This change was made because in 4.0, [this check](https://github.com/canjs/can-util/blob/7e8669a666072dcbdcc34402b640a67d38ea5784/dom/events/events.js#L81) was returning false when run in the main production build of CanJS (where can-simple-dom is also packaged).